### PR TITLE
feat: adds keyboard shortcut for starting a translation

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -87,7 +87,6 @@ export const languages = [
   {
     label: 'English (en)',
     code: 'en',
-    default: true,
   },
   {
     label: 'Estonian (et)',
@@ -313,5 +312,6 @@ export enum AwsOptions {
  */
 export enum ExtensionOptions {
   CACHING_ENABLED = 'cachingEnabled',
+  DEFAULT_SOURCE_LANG = 'defaultSourceLang',
   DEFAULT_TARGET_LANG = 'defaultTargetLang',
 }

--- a/src/contentScripts/functions.ts
+++ b/src/contentScripts/functions.ts
@@ -1,3 +1,7 @@
+/**
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  SPDX-License-Identifier: Apache-2.0
+*/
 import {
   TranslateClient,
   TranslateTextCommand,
@@ -288,4 +292,35 @@ export function applyTranslation(nodeMap: NodeMap, pages: string[]): void {
       node.textContent = text;
     }
   });
+}
+
+/**
+ * Creates an overlay that indicates the page is current translating.
+ */
+export function createOverlay(): void {
+  const body = document.querySelector('body');
+
+  const container = document.createElement('div');
+  container.id = 'amazon-translate-overlay';
+  container.innerText = 'Translating...';
+  container.style.position = 'fixed';
+  container.style.bottom = '0';
+  container.style.left = '0';
+  container.style.zIndex = '1000000000';
+  container.style.padding = '5px';
+  container.style.color = '#ffffff';
+  container.style.fontSize = '16px';
+  container.style.fontWeight = 'bold';
+  container.style.fontFamily = 'Arial';
+  container.style.backgroundColor = '#dd6b10';
+
+  body?.appendChild(container);
+}
+
+/**
+ * Destroys the translating indicator.
+ */
+export function destroyOverlay(): void {
+  const overlay = document.querySelector('#amazon-translate-overlay');
+  overlay?.parentNode?.removeChild(overlay);
 }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -13,6 +13,15 @@ export async function getManifest(): Promise<Manifest.WebExtensionManifest> {
     name: pkg.displayName || pkg.name,
     version: pkg.version,
     description: pkg.description,
+    commands: {
+      // @ts-expect-error The current type system doesn't understand the command API.
+      translate: {
+        suggested_key: {
+          default: 'Alt+Shift+T',
+        },
+        description: 'Translate the webpage with your default source language and target language.',
+      },
+    },
     browser_action: {
       default_icon: './assets/logo.png',
       default_popup: './dist/popup/index.html',

--- a/src/options/Options.vue
+++ b/src/options/Options.vue
@@ -97,6 +97,9 @@
           For more detailed information about setting up this extension, refer to the following AWS Blog post:
           <a href="https://aws.amazon.com/blogs/machine-learning/use-a-web-browser-plugin-to-quickly-translate-text-with-amazon-translate/">Use a web browser plugin to quickly translate text with Amazon Translate</a>
         </li>
+        <li>
+          <strong>Hint:</strong> You can translate a page with your default source language and target language by pressing the keys <em>Alt + Shift + T</em>.
+        </li>
       </ul>
 
       <div class="aws-form-row">

--- a/src/options/Options.vue
+++ b/src/options/Options.vue
@@ -3,17 +3,11 @@
   SPDX-License-Identifier: Apache-2.0
 -->
 <script lang="ts">
-  import AwsButton from '../components/AwsButton.vue';
-  import ShowButton from '../components/ShowButton.vue';
   import { lockr } from '../modules';
   import regionData from './regions.json';
   import { AwsOptions, ExtensionOptions, languages } from '~/constants';
 
   export default defineComponent({
-    components: {
-      AwsButton,
-      ShowButton,
-    },
     data() {
       return {
         regions: regionData.regions,
@@ -27,6 +21,7 @@
           awsAccessKeyId: '',
           awsSecretAccessKey: '',
           password: '',
+          defaultSourceLang: 'auto',
           defaultTargetLang: 'en',
           cachingEnabled: true,
         },
@@ -39,14 +34,21 @@
        */
       saveSettings() {
         // Get the values
-        const { awsRegion, awsAccessKeyId, awsSecretAccessKey, defaultTargetLang, cachingEnabled } =
-          this.configuration;
+        const {
+          awsRegion,
+          awsAccessKeyId,
+          awsSecretAccessKey,
+          defaultSourceLang,
+          defaultTargetLang,
+          cachingEnabled,
+        } = this.configuration;
 
         // Validate that the values are all set
         if (awsRegion !== '' && awsAccessKeyId !== '' && awsSecretAccessKey !== '') {
           lockr.set(AwsOptions.AWS_REGION, awsRegion);
           lockr.set(AwsOptions.AWS_ACCESS_KEY_ID, awsAccessKeyId);
           lockr.set(AwsOptions.AWS_SECRET_ACCESS_KEY, awsSecretAccessKey);
+          lockr.set(ExtensionOptions.DEFAULT_SOURCE_LANG, defaultSourceLang);
           lockr.set(ExtensionOptions.DEFAULT_TARGET_LANG, defaultTargetLang);
           lockr.set(ExtensionOptions.CACHING_ENABLED, cachingEnabled);
 
@@ -63,11 +65,12 @@
     async mounted() {
       this.hasError = false;
       this.message = '';
-      this.configuration.awsRegion = lockr.get('awsRegion', '');
-      this.configuration.awsAccessKeyId = lockr.get('awsAccessKeyId', '');
-      this.configuration.awsSecretAccessKey = lockr.get('awsSecretAccessKey', '');
-      this.configuration.defaultTargetLang = lockr.get('defaultTargetLang', 'en');
-      this.configuration.cachingEnabled = lockr.get('cachingEnabled', true);
+      this.configuration.awsRegion = lockr.get(AwsOptions.AWS_REGION, '');
+      this.configuration.awsAccessKeyId = lockr.get(AwsOptions.AWS_ACCESS_KEY_ID, '');
+      this.configuration.awsSecretAccessKey = lockr.get(AwsOptions.AWS_SECRET_ACCESS_KEY, '');
+      this.configuration.defaultSourceLang = lockr.get(ExtensionOptions.DEFAULT_SOURCE_LANG, 'auto');
+      this.configuration.defaultTargetLang = lockr.get(ExtensionOptions.DEFAULT_TARGET_LANG, 'en');
+      this.configuration.cachingEnabled = lockr.get(ExtensionOptions.CACHING_ENABLED, true);
     },
   });
 </script>
@@ -143,17 +146,34 @@
       </div>
 
       <div class="aws-form-row">
-        <label for="aws-region">Default Target Language</label>
-        <p>Set the language you would like to translate to by default.</p>
-        <select v-model="configuration.defaultTargetLang" class="aws-field">
+        <label for="aws-region">Default Source Language</label>
+        <p>Set the language you would like to translate from by default.</p>
+        <select v-model="configuration.defaultSourceLang" class="aws-field">
           <option
             v-for="lang in languages"
             :key="lang.code"
             :value="lang.code"
-            :selected="lang.default"
+            :selected="lang.code === configuration.defaultSourceLang"
           >
             {{ lang.label }}
           </option>
+        </select>
+      </div>
+
+      <div class="aws-form-row">
+        <label for="aws-region">Default Target Language</label>
+        <p>Set the language you would like to translate to by default.</p>
+        <select v-model="configuration.defaultTargetLang" class="aws-field">
+          <template v-for="lang in languages">
+            <option
+              v-if="lang.code !== 'auto'"
+              :key="lang.code"
+              :value="lang.code"
+              :selected="lang.code === configuration.defaultTargetLang"
+            >
+              {{ lang.label }}
+            </option>
+          </template>
         </select>
       </div>
 

--- a/src/popup/Popup.vue
+++ b/src/popup/Popup.vue
@@ -142,7 +142,6 @@
             v-for="lang in languages"
             :key="lang.code"
             :value="lang.code"
-            :selected="lang.default"
           >
             {{ lang.label }}
           </option>

--- a/src/popup/Popup.vue
+++ b/src/popup/Popup.vue
@@ -30,6 +30,7 @@
       this.region = lockr.get(AwsOptions.AWS_REGION, '');
       this.accessKeyId = lockr.get(AwsOptions.AWS_ACCESS_KEY_ID, '');
       this.secretAccessKey = lockr.get(AwsOptions.AWS_SECRET_ACCESS_KEY, '');
+      this.form.sourceLang = lockr.get(ExtensionOptions.DEFAULT_SOURCE_LANG, 'auto');
       this.form.targetLang = lockr.get(ExtensionOptions.DEFAULT_TARGET_LANG, 'en');
       this.cachingEnabled = lockr.get(ExtensionOptions.CACHING_ENABLED, false);
 

--- a/src/util/tabs.ts
+++ b/src/util/tabs.ts
@@ -1,3 +1,8 @@
+/**
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  SPDX-License-Identifier: Apache-2.0
+*/
+
 import type { Tabs } from 'webextension-polyfill';
 
 /**

--- a/test/contentScripts.ts
+++ b/test/contentScripts.ts
@@ -1,3 +1,7 @@
+/**
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  SPDX-License-Identifier: Apache-2.0
+*/
 import test from 'ava';
 import {
   crawl,
@@ -7,14 +11,7 @@ import {
   writePages,
   bindPages,
 } from '../src/contentScripts/functions';
-import {
-  DOM,
-  DOM_WITH_EMPTY,
-  DOM_EL_POPULATED,
-  DOM_EL_EMPTY,
-  pageMap,
-  // nodeMap,
-} from './data';
+import { DOM, DOM_WITH_EMPTY, DOM_EL_POPULATED, DOM_EL_EMPTY, pageMap } from './data';
 
 test.before(() => {
   global.Blob = DOM.window.Blob;

--- a/test/indicator.ts
+++ b/test/indicator.ts
@@ -38,5 +38,5 @@ test.serial('destroys the translating indicator overlay', t => {
   destroyOverlay();
 
   const overlay = document.querySelector<HTMLDivElement>('#amazon-translate-overlay');
-  t.is(overlay, undefined);
+  t.is(overlay, null);
 });

--- a/test/indicator.ts
+++ b/test/indicator.ts
@@ -1,0 +1,42 @@
+/**
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  SPDX-License-Identifier: Apache-2.0
+*/
+import test from 'ava';
+import { JSDOM } from 'jsdom';
+import { createOverlay, destroyOverlay } from '../src/contentScripts/functions';
+
+const docString = '<html><body></body></html>';
+
+test.beforeEach(() => {
+  global.document = new JSDOM(docString).window.document;
+});
+
+test.serial('creates an overlay div that indicates the page is currently translating', t => {
+  createOverlay();
+
+  const overlay = document.querySelector<HTMLDivElement>('#amazon-translate-overlay');
+
+  t.is(overlay?.id, 'amazon-translate-overlay');
+  t.is(overlay?.innerText, 'Translating...');
+  t.is(overlay?.style?.position, 'fixed');
+  t.is(overlay?.style.bottom, '0px');
+  t.is(overlay?.style.left, '0px');
+  t.is(overlay?.style.zIndex, '1000000000');
+  t.is(overlay?.style.padding, '5px');
+  t.is(overlay?.style.color, 'rgb(255, 255, 255)');
+  t.is(overlay?.style.fontSize, '16px');
+  t.is(overlay?.style.fontWeight, 'bold');
+  t.is(overlay?.style.fontFamily, 'Arial');
+  t.is(overlay?.style.backgroundColor, 'rgb(221, 107, 16)');
+
+  destroyOverlay();
+});
+
+test.serial('destroys the translating indicator overlay', t => {
+  createOverlay();
+  destroyOverlay();
+
+  const overlay = document.querySelector<HTMLDivElement>('#amazon-translate-overlay');
+  t.is(overlay, undefined);
+});


### PR DESCRIPTION
*Issue #, if available:* fix #27

*Description of changes:*

Adds support for translating a web page using the keyboard shortcut Alt+Shift+T and translates using
the configured default source language and default target language. Translations now display an
indicator on the bottom left of the screen while translating the page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
