### PR TITLE
fix: page crawling now ignores <code> nodes

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,54 @@
   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
   SPDX-License-Identifier: Apache-2.0
 */
+
+/*-----------------------------*\
+ * Lockr
+\*-----------------------------*/
+
 export const LOCKR_PREFIX = 'amazonTranslate_';
+
+/*-----------------------------*\
+ * Crawling and Parsing
+\*-----------------------------*/
+
+// The maximum translate document size in bytes
+export const DOC_BOUNDARY = 500;
+
+// Node types that the crawler should ignore
+export const IGNORED_NODES = ['SCRIPT', 'STYLE', 'PRE', '#comment', 'NOSCRIPT', 'CODE'];
+
+// The pattern that all pages should conform to
+export const PAGE_PATTERN = /<\|\d+:(?<=:).*?(?=\|)\|>/g;
+
+// The pattern to split translated documents into pages
+export const PAGE_SPLIT_PATTERN = /[(<|)|(|>)]/g;
+
+/*-----------------------------*\
+ * localStorage Access Keys
+\*-----------------------------*/
+
+/**
+ * Local storage keys for AWS credentials.
+ */
+export enum AwsOptions {
+  AWS_REGION = 'awsRegion',
+  AWS_ACCESS_KEY_ID = 'awsAccessKeyId',
+  AWS_SECRET_ACCESS_KEY = 'awsSecretAccessKey',
+}
+
+/**
+ * Local storage keys for extension options.
+ */
+export enum ExtensionOptions {
+  CACHING_ENABLED = 'cachingEnabled',
+  DEFAULT_SOURCE_LANG = 'defaultSourceLang',
+  DEFAULT_TARGET_LANG = 'defaultTargetLang',
+}
+
+/*-----------------------------*\
+ * Language Lists
+\*-----------------------------*/
 
 /**
  * Array of objects representing the languages that are supported by Amazon Translate.
@@ -297,21 +344,3 @@ export const languages = [
     code: 'cy',
   },
 ];
-
-/**
- * Local storage keys for AWS credentials.
- */
-export enum AwsOptions {
-  AWS_REGION = 'awsRegion',
-  AWS_ACCESS_KEY_ID = 'awsAccessKeyId',
-  AWS_SECRET_ACCESS_KEY = 'awsSecretAccessKey',
-}
-
-/**
- * Local storage keys for extension options.
- */
-export enum ExtensionOptions {
-  CACHING_ENABLED = 'cachingEnabled',
-  DEFAULT_SOURCE_LANG = 'defaultSourceLang',
-  DEFAULT_TARGET_LANG = 'defaultTargetLang',
-}

--- a/src/contentScripts/functions.ts
+++ b/src/contentScripts/functions.ts
@@ -17,15 +17,7 @@ import {
   CacheLangs,
   CacheTextMap,
 } from '../_contracts';
-
-// The maximum translate document size in bytes
-const DOC_BOUNDARY = 500;
-// Node types that the crawler should ignore
-const IGNORED_NODES = ['SCRIPT', 'STYLE', 'PRE', '#comment', 'NOSCRIPT'];
-// The formatting to apply to pages before translation
-const PAGE_PATTERNIZE = (id: string, text: string) => `<|${id}:${text}|>`;
-// The pattern to split translated documents into pages
-const PAGE_PATTERN = /[(<|)|(|>)]/g;
+import { IGNORED_NODES, DOC_BOUNDARY, PAGE_SPLIT_PATTERN } from '../constants';
 
 /**
  * Recursively crawls the webpage starting from the specified starting node and translates
@@ -77,7 +69,7 @@ export function validNodeText(node: Node): string | null {
  * Example Page: "<|1:some text|>"
  */
 export function writePages(pages: PageMap): string[] {
-  return Object.entries(pages).map(([key, text]) => PAGE_PATTERNIZE(key, text));
+  return Object.entries(pages).map(([key, text]) => pagePatternize(key, text));
 }
 
 /**
@@ -199,7 +191,9 @@ function translateDocument(
 export function breakDocuments(docs: Documents): string[] {
   return docs.reduce(
     (acc, doc) =>
-      acc.concat(doc.split(PAGE_PATTERN).filter((line: string) => line !== '' && line !== ' ')),
+      acc.concat(
+        doc.split(PAGE_SPLIT_PATTERN).filter((line: string) => line !== '' && line !== ' ')
+      ),
     [] as string[]
   );
 }
@@ -292,6 +286,13 @@ export function applyTranslation(nodeMap: NodeMap, pages: string[]): void {
       node.textContent = text;
     }
   });
+}
+
+/**
+ * Applies template formatting to pages for later parsing.
+ */
+export function pagePatternize(id: string, text: string): string {
+  return `<|${id}:${text}|>`;
 }
 
 /**

--- a/test/contentScripts.ts
+++ b/test/contentScripts.ts
@@ -4,69 +4,17 @@
 */
 import test from 'ava';
 import {
-  crawl,
   breakPages,
   breakDocuments,
-  validNodeText,
   writePages,
   bindPages,
+  pagePatternize,
 } from '../src/contentScripts/functions';
-import { DOM, DOM_WITH_EMPTY, DOM_EL_POPULATED, DOM_EL_EMPTY, pageMap } from './data';
+import { PAGE_PATTERN } from '../src/constants';
+import { DOM, pageMap } from './data';
 
 test.before(() => {
   global.Blob = DOM.window.Blob;
-});
-
-test('crawls a web page and returns a pageMap and a nodeMap', t => {
-  const body = DOM.window.document.querySelector('body');
-  if (body) {
-    const { pageMap, nodeMap } = crawl(body);
-
-    // Test the pageMap
-    t.is(pageMap[1], '\n        child 1 text node\n      ');
-    t.is(pageMap[2], '\n        child 2 text node\n      ');
-    t.is(pageMap[3], '\n        parent 2 child text node\n        ');
-    t.is(pageMap[4], '\n          parent 2 grandchild p tag\n        ');
-
-    // Test the nodeMap (textNodes have a type of number 3)
-    t.is(nodeMap[1].nodeType, 3);
-    t.is(nodeMap[2].nodeType, 3);
-    t.is(nodeMap[3].nodeType, 3);
-    t.is(nodeMap[4].nodeType, 3);
-  } else {
-    t.fail();
-  }
-});
-
-test('crawling a web page does not return empty text nodes', t => {
-  const body = DOM_WITH_EMPTY.window.document.querySelector('body');
-  if (body) {
-    const { pageMap, nodeMap } = crawl(body);
-
-    // Test the pageMap
-    t.is(Object.entries(pageMap).length, 1);
-    t.is(pageMap[1], "I'm not empty");
-
-    // Test the nodeMap (textNodes have a type of number 3)
-    t.is(nodeMap[1].nodeType, 3);
-  } else {
-    t.fail();
-  }
-});
-
-test('validate that the given DOM node is a TEXT_NODE and consists of characters other than white-space and line-breaks.', t => {
-  const p1 = DOM_EL_POPULATED.window.document.querySelector('#test');
-  const p2 = DOM_EL_EMPTY.window.document.querySelector('#test');
-
-  if (p1 && p2) {
-    const result1 = validNodeText(p1.childNodes[0]);
-    const result2 = validNodeText(p2.childNodes[0]);
-
-    t.is(result1, 'populated text');
-    t.falsy(result2);
-  } else {
-    t.fail();
-  }
 });
 
 test('creates an array of pages from a page map', t => {
@@ -75,6 +23,15 @@ test('creates an array of pages from a page map', t => {
   t.is(pages[0], '<|1:some text|>');
   t.is(pages[1], '<|2:more text|>');
   t.is(pages[2], '<|3:even more text|>');
+});
+
+test('applies correct template pattern to pages', t => {
+  const result = pagePatternize('64', 'Hello world!');
+  const matched = result.match(PAGE_PATTERN);
+
+  // We can't use the t.regex() assertion because it passes as long as a part of the string matches
+  t.is(matched?.length, 1, 'The result did not match page pattern.');
+  t.is(matched?.[0].length, result.length, 'The matched string and the result differ.');
 });
 
 test('Takes DOM text pages (text lines) and binds them into documents (chunks)', t => {

--- a/test/crawling.ts
+++ b/test/crawling.ts
@@ -1,0 +1,130 @@
+/**
+  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  SPDX-License-Identifier: Apache-2.0
+*/
+import test from 'ava';
+import { crawl, validNodeText } from '../src/contentScripts/functions';
+import {
+  DOM,
+  DOM_WITH_EMPTY,
+  DOM_EL_POPULATED,
+  DOM_EL_EMPTY,
+  DOM_EL_CODE,
+  DOM_EL_COMMENT,
+  DOM_EL_NOSCRIPT,
+  DOM_EL_PRE,
+  DOM_EL_SCRIPT,
+  DOM_EL_STYLE,
+} from './data';
+
+test('crawls a web page and returns a pageMap and a nodeMap', t => {
+  const body = DOM.window.document.querySelector('body');
+  if (body) {
+    const { pageMap, nodeMap } = crawl(body);
+
+    // Test the pageMap
+    t.is(pageMap[1], '\n        child 1 text node\n      ');
+    t.is(pageMap[2], '\n        child 2 text node\n      ');
+    t.is(pageMap[3], '\n        parent 2 child text node\n        ');
+    t.is(pageMap[4], '\n          parent 2 grandchild p tag\n        ');
+
+    // Test the nodeMap (textNodes have a type of number 3)
+    t.is(nodeMap[1].nodeType, 3);
+    t.is(nodeMap[2].nodeType, 3);
+    t.is(nodeMap[3].nodeType, 3);
+    t.is(nodeMap[4].nodeType, 3);
+  } else {
+    t.fail();
+  }
+});
+
+test('crawling a web page does not return text from <code> nodes', t => {
+  const body = DOM_EL_CODE.window.document.querySelector('body');
+  if (body) {
+    const { pageMap } = crawl(body);
+    t.is(Object.keys(pageMap).length, 0);
+  } else {
+    t.fail();
+  }
+});
+
+test('crawling a web page does not return text from <!-- comment --> nodes', t => {
+  const body = DOM_EL_COMMENT.window.document.querySelector('body');
+  if (body) {
+    const { pageMap } = crawl(body);
+    t.is(Object.keys(pageMap).length, 0);
+  } else {
+    t.fail();
+  }
+});
+
+test('crawling a web page does not return text from <noscript> nodes', t => {
+  const body = DOM_EL_NOSCRIPT.window.document.querySelector('body');
+  if (body) {
+    const { pageMap } = crawl(body);
+    t.is(Object.keys(pageMap).length, 0);
+  } else {
+    t.fail();
+  }
+});
+
+test('crawling a web page does not return text from <pre> nodes', t => {
+  const body = DOM_EL_PRE.window.document.querySelector('body');
+  if (body) {
+    const { pageMap } = crawl(body);
+    t.is(Object.keys(pageMap).length, 0);
+  } else {
+    t.fail();
+  }
+});
+
+test('crawling a web page does not return text from <script> nodes', t => {
+  const body = DOM_EL_SCRIPT.window.document.querySelector('body');
+  if (body) {
+    const { pageMap } = crawl(body);
+    t.is(Object.keys(pageMap).length, 0);
+  } else {
+    t.fail();
+  }
+});
+
+test('crawling a web page does not return text from <style> nodes', t => {
+  const body = DOM_EL_STYLE.window.document.querySelector('body');
+  if (body) {
+    const { pageMap } = crawl(body);
+    t.is(Object.keys(pageMap).length, 0);
+  } else {
+    t.fail();
+  }
+});
+
+test('crawling a web page does not return empty text nodes', t => {
+  const body = DOM_WITH_EMPTY.window.document.querySelector('body');
+  if (body) {
+    const { pageMap, nodeMap } = crawl(body);
+
+    // Test the pageMap
+    t.is(Object.entries(pageMap).length, 1);
+    t.is(pageMap[1], "I'm not empty");
+
+    // Test the nodeMap (textNodes have a type of number 3)
+    t.is(nodeMap[1].nodeType, 3);
+  } else {
+    t.fail();
+  }
+});
+
+test('validate that the given DOM node is a TEXT_NODE and consists of characters other than white-space and line-breaks.', t => {
+  const p1 = DOM_EL_POPULATED.window.document.querySelector('#test');
+  const p2 = DOM_EL_EMPTY.window.document.querySelector('#test');
+
+  if (p1 && p2) {
+    const result1 = validNodeText(p1.childNodes[0]);
+    const result2 = validNodeText(p2.childNodes[0]);
+
+    t.is(result1, 'populated text');
+    t.falsy(result2);
+  } else {
+    t.fail();
+  }
+});

--- a/test/data/dom.ts
+++ b/test/data/dom.ts
@@ -1,12 +1,20 @@
 import { JSDOM } from 'jsdom';
 
-export const DOM = new JSDOM(`
+const BASE_DOM_START = `
 <!DOCTYPE html>
 <html>
 <head>
   <title>TEST DOM</title>
 </head>
-<body>
+<body>`;
+
+const BASE_DOM_END = `
+</body>
+</html>
+`;
+
+export const DOM = new JSDOM(`
+${BASE_DOM_START}
   <div class="ancestor">
     <div class="parent1">
       <p class="child1">
@@ -25,22 +33,42 @@ export const DOM = new JSDOM(`
       </div>
     </div>
   </div>
-</body>
-</html>
+${BASE_DOM_END}
 `);
 
 export const DOM_WITH_EMPTY = new JSDOM(`
-<!DOCTYPE html>
-<html>
-<head>
-  <title>TEST DOM</title>
-</head>
-<body>
+${BASE_DOM_START}
   <p>I'm not empty</p>
   <p>       </p>
-</body>
-</html>
+${BASE_DOM_END}
 `);
 
-export const DOM_EL_POPULATED = new JSDOM(`<!DOCTYPE html><p id="test">populated text</p>`);
-export const DOM_EL_EMPTY = new JSDOM(`<!DOCTYPE html><p id="test">     </p>`);
+export const DOM_EL_POPULATED = new JSDOM(
+  `${BASE_DOM_START}<p id="test">populated text</p>${BASE_DOM_END}`
+);
+
+export const DOM_EL_EMPTY = new JSDOM(`${BASE_DOM_START}<p id="test">     </p>${BASE_DOM_END}`);
+
+export const DOM_EL_SCRIPT = new JSDOM(
+  `${BASE_DOM_START}<script>console.log('hello world!');</script>${BASE_DOM_END}`
+);
+
+export const DOM_EL_STYLE = new JSDOM(
+  `${BASE_DOM_START}<style>.error { color: red; }</style>${BASE_DOM_END}`
+);
+
+export const DOM_EL_PRE = new JSDOM(
+  `${BASE_DOM_START}<pre>console.log('hello world!');</pre>${BASE_DOM_END}`
+);
+
+export const DOM_EL_COMMENT = new JSDOM(
+  `${BASE_DOM_START}<!-- This is a comment. -->${BASE_DOM_END}`
+);
+
+export const DOM_EL_NOSCRIPT = new JSDOM(
+  `${BASE_DOM_START}<noscript>JavaScript is disabled.</noscript>${BASE_DOM_END}`
+);
+
+export const DOM_EL_CODE = new JSDOM(
+  `${BASE_DOM_START}<code>$: npm run test</code>${BASE_DOM_END}`
+);


### PR DESCRIPTION
Page crawling now ignores <code> nodes when extracting text. Cleaned up some code and added more
unit tests.

fix #31

*Issue #, if available:* #31

*Description of changes:*

Page crawling now ignores <code> nodes when extracting text. Cleaned up some code and added more
unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
