### PR TITLE
feat: add a context menu option to translate the selected text

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ of the translation of the page and reduces the amount of requests made to the Am
 If you would like to re-run a translation for a page, the extension popup should show a link that allows you to clear the cache for the current page.
 Once the cache is cleared your next translate request will use the Amazon Translate service for a fresh translation. The new translation will now be cached.
 
+## Development
+To develop this extension, follow the steps below:
+1. Install the dependencies `pnpm install`.
+2. Start the development server: `npm run dev`.
+3. Load the `extensions` folder as an unpacked extension.
+
 ## Contributing
 
 Please read our contributing documentation before writing any code: [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -20,7 +20,7 @@ import { Tabs } from 'webextension-polyfill';
 import { getCurrentTabId } from '../util';
 import { lockr } from '../modules';
 import { AwsOptions, ExtensionOptions } from '~/constants';
-import { translateDocuments } from '../contentScripts/functions';
+import { translateMany } from '../contentScripts/functions';
 
 // @ts-ignore only on dev mode
 if (import.meta.hot) {
@@ -144,7 +144,7 @@ function translateSelectionHandler() {
             tabId,
           }
         );
-        const translatedDocs = await translateDocuments(
+        const translatedDocs = await translateMany(
           {
             region: lockr.get(AwsOptions.AWS_REGION, ''),
             credentials: {

--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -136,6 +136,15 @@ function translateSelectionHandler() {
   browser.contextMenus.onClicked.addListener((info): void => {
     void (async () => {
       if (info.menuItemId === 'translate-selection') {
+        const tabId = await getCurrentTabId();
+        void sendMessage(
+          'show-overlay',
+          {},
+          {
+            context: 'content-script',
+            tabId,
+          }
+        );
         const translatedDocs = await translateDocuments(
           {
             region: lockr.get(AwsOptions.AWS_REGION, ''),
@@ -149,7 +158,6 @@ function translateSelectionHandler() {
           [info.selectionText]
         );
 
-        const tabId = await getCurrentTabId();
         void sendMessage(
           'translate-selection',
           { translatedText: escape(translatedDocs[0]) },

--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -96,6 +96,7 @@ browser.tabs.onActivated.addListener(({ tabId }) => {
     .then(tab => {
       previousTabId = tabId;
       console.info('previous tab', tab);
+      console.info('test');
       void sendMessage('tab-prev', { title: tab.title }, { context: 'content-script', tabId });
     })
     .catch(() => {
@@ -148,9 +149,16 @@ function translateSelectionHandler() {
           [info.selectionText]
         );
 
-        const alertWindow = `alert('${escape(translatedDocs[0])}')`;
-        void browser.tabs.executeScript({ code: alertWindow });
+        const tabId = await getCurrentTabId();
+        void sendMessage(
+          'translate-selection',
+          { translatedText: escape(translatedDocs[0]) },
+          {
+            context: 'content-script',
+            tabId,
+          }
+        );
       }
-    });
+    })();
   });
 }

--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -120,11 +120,17 @@ onMessage('get-current-tab', async () => {
   }
 });
 
-// Translate selection with right-click menu
+/**
+ * Escape special characters for passing strings safely between
+ * background script and content script
+ */
 const escape = (text: string): string => {
   return text.replaceAll('"', '\\"').replaceAll("'", "\\'");
 };
 
+/**
+ * Translate selection in a popup using right-click menu
+ */
 function translateSelectionHandler() {
   browser.contextMenus.create({
     title: 'Translate selection',

--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -96,7 +96,6 @@ browser.tabs.onActivated.addListener(({ tabId }) => {
     .then(tab => {
       previousTabId = tabId;
       console.info('previous tab', tab);
-      console.info('test');
       void sendMessage('tab-prev', { title: tab.title }, { context: 'content-script', tabId });
     })
     .catch(() => {

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -131,6 +131,7 @@ function translateSelectionHandler() {
 
     body?.appendChild(container);
 
+    // Close the popup when clicked outside
     document.body.addEventListener(
       'click',
       () => {

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -85,6 +85,9 @@ function translateHandler() {
   );
 }
 
+/**
+ * Show the result of "translate selections in popup" message from background script
+ */
 function translateSelectionHandler() {
   onMessage<TranslateCommandData, 'translate-selection'>('translate-selection', ({ data }) => {
     const { translatedText } = data;

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -26,10 +26,20 @@ import { startTranslation } from './translate';
 (() => {
   // Setup message handlers. These handlers receive messages from the popup window.
   translateHandler();
+  showOverlayHandler();
   translateSelectionHandler();
   clearCacheHandler();
   tabPrevHandler();
 })();
+
+/**
+ * Show the "translating..." overlay
+ */
+function showOverlayHandler() {
+  onMessage<TranslateCommandData, 'show-overlay'>('show-overlay', () => {
+    createOverlay();
+  });
+}
 
 /**
  * Listen for messages from the popup window that contain the AWS creds and selected
@@ -120,6 +130,8 @@ function translateSelectionHandler() {
     container.appendChild(closeButton);
 
     body?.appendChild(container);
+
+    destroyOverlay();
   });
 }
 

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -26,6 +26,7 @@ import { startTranslation } from './translate';
 (() => {
   // Setup message handlers. These handlers receive messages from the popup window.
   translateHandler();
+  translateSelectionHandler();
   clearCacheHandler();
   tabPrevHandler();
 })();
@@ -72,6 +73,54 @@ function translateHandler() {
         });
     }
   );
+}
+
+function translateSelectionHandler() {
+  onMessage<TranslateCommandData, 'translate-selection'>('translate-selection', ({ data }) => {
+    const { translatedText } = data;
+
+    const body = document.querySelector('body');
+
+    const container = document.createElement('div');
+    container.id = 'amazon-translate-popup';
+    container.style.position = 'fixed';
+    container.style.bottom = '0px';
+    container.style.left = '0px';
+    container.style.width = '98vw';
+    container.style.maxWidth = '98%';
+    container.style.zIndex = '1000000000';
+    container.style.padding = '20px';
+    container.style.color = '#000000';
+    container.style.fontSize = '16px';
+    container.style.fontWeight = 'normal';
+    container.style.fontFamily = 'Arial';
+    container.style.backgroundColor = '#ffffff';
+    container.style.boxShadow = '0px 0px 20px #000000';
+
+    const closeButton = document.createElement('div');
+    closeButton.innerText = 'x';
+    closeButton.style.position = 'absolute';
+    closeButton.style.top = '10px';
+    closeButton.style.left = '10px';
+    closeButton.addEventListener('click', event => {
+      const containerBox = event.target?.parentNode;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      containerBox.parentNode?.removeChild(containerBox);
+    });
+
+    const title = document.createElement('h3');
+    title.innerText = 'Amazon Translate';
+
+    const translatedTextElement = document.createElement('p');
+    translatedTextElement.innerText = translatedText;
+    translatedTextElement.width = '90%';
+
+    container.appendChild(title);
+    container.appendChild(translatedTextElement);
+    container.appendChild(closeButton);
+
+    body?.appendChild(container);
+  });
 }
 
 /**

--- a/src/contentScripts/index.ts
+++ b/src/contentScripts/index.ts
@@ -131,6 +131,18 @@ function translateSelectionHandler() {
 
     body?.appendChild(container);
 
+    document.body.addEventListener(
+      'click',
+      () => {
+        container.parentNode.removeChild(container);
+      },
+      { once: true }
+    );
+
+    container.addEventListener('click', event => {
+      event.stopPropagation();
+    });
+
     destroyOverlay();
   });
 }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -40,7 +40,7 @@ export async function getManifest(): Promise<Manifest.WebExtensionManifest> {
       48: './assets/logo.png',
       128: './assets/logo.png',
     },
-    permissions: ['tabs', 'storage', 'activeTab', 'http://*/', 'https://*/'],
+    permissions: ['tabs', 'storage', 'activeTab', 'http://*/', 'https://*/', 'contextMenus'],
     content_scripts: [
       {
         matches: ['http://*/*', 'https://*/*'],


### PR DESCRIPTION
This adds a context menu option for you to translate the selected text. 
![Screenshot 2022-03-03 at 15 01 47](https://user-images.githubusercontent.com/3250983/156582261-741196e3-8595-499e-ab4c-00f6907ea179.png)
![Screenshot 2022-03-03 at 15 01 55](https://user-images.githubusercontent.com/3250983/156582293-c0cb021e-f3b3-43f1-9d8e-8c494863cdfa.png)

* Issue #26*  

*Description of changes:*

This is a draft PR for #26. I need to discuss with you about the UI design. Currently I'm using an `alert` for simplicity. 
Also I'm directly doing the translation in the background script. Since there is no need to pass the string to the content script and let content script translate it. Please let me know if this is acceptable. 

Also apologies in advance if I didn't comply with your coding convention, test coverage requirements, commit message conventions etc. Please kindly let me know your conventions and quality requirements and I'll try to fix them ASAP. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
