### PR TITLE
fix: fixed PAGE_SPLIT_PATTERN to correctly split text containing parentheses

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,7 +23,7 @@ export const IGNORED_NODES = ['SCRIPT', 'STYLE', 'PRE', '#comment', 'NOSCRIPT', 
 export const PAGE_PATTERN = /<\|\d+:(?<=:).*?(?=\|)\|>/g;
 
 // The pattern to split translated documents into pages
-export const PAGE_SPLIT_PATTERN = /[(<|)|(|>)]/g;
+export const PAGE_SPLIT_PATTERN = /(?:<\|)|(?:\|>)/g;
 
 /*-----------------------------*\
  * localStorage Access Keys

--- a/test/contentScripts.ts
+++ b/test/contentScripts.ts
@@ -42,12 +42,17 @@ test('Takes DOM text pages (text lines) and binds them into documents (chunks)',
 });
 
 test('breaks documents into pages', t => {
-  const documents = ['<|1:algún texto|><|2:más texto|>', '<|3:aún más texto|>'];
+  const documents = [
+    '<|1:algún texto|><|2:más texto|>',
+    '<|3:aún más texto|>',
+    '<|4:more (more) text|>',
+  ];
   const pages = breakDocuments(documents);
 
   t.is(pages[0], '1:algún texto');
   t.is(pages[1], '2:más texto');
   t.is(pages[2], '3:aún más texto');
+  t.is(pages[3], '4:more (more) text');
 });
 
 test('breaks pages into a pageMap', t => {


### PR DESCRIPTION
*Issue #, if available:* fix #37

*Description of changes:* Edit regex(PAGE_SPLIT_PATTERN) to correctly split text containing parentheses.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
