### PR TITLE
Changes made to fix issues 46,47 and 51

### DIFF
--- a/src/_contracts/translate.ts
+++ b/src/_contracts/translate.ts
@@ -8,6 +8,12 @@ export interface TranslateData {
 
 export type Documents = string[];
 
+export type TranslatedDocuments = {
+  translatedText: Documents;
+  sourceLanguage: string;
+};
+
+export type SourceLanguauge = string;
 export interface NodeMap {
   [key: string]: Node;
 }

--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -170,7 +170,7 @@ browser.contextMenus.onClicked.addListener((info): void => {
 
       void sendMessage(
         'translate-selection',
-        { translatedText: escape(translatedDocs[0]) },
+        { translatedText: escape(translatedDocs.translatedText[0]) },
         {
           context: 'content-script',
           tabId,
@@ -179,4 +179,3 @@ browser.contextMenus.onClicked.addListener((info): void => {
     }
   })();
 });
-// }


### PR DESCRIPTION
## Bug Fix
[Issue #46](https://github.com/awslabs/amazon-translate-browser-extension/issues/46) - Clicking translate button twice removes elements from the DOM

*Description of changes:*
`langpair` in the cache is not accurate so modified the code to get the accurate lang code from API call. 

[Issue #47](https://github.com/awslabs/amazon-translate-browser-extension/issues/47) - Translating overlay does not display on page

*Description of changes:*
Above fix also fixed this issue.

## Enhancement
[Issue #51](https://github.com/awslabs/amazon-translate-browser-extension/issues/51) - Client side Validation when same translating language is selected

*Description of changes:*
Capture the previous selected target language and added a validation. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

closes #46
closes #47
closes #51
